### PR TITLE
Fix environment variable name

### DIFF
--- a/client.js
+++ b/client.js
@@ -2,7 +2,7 @@ import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_KEY
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 )
 
 export { supabase }


### PR DESCRIPTION
In the README the instruction is `NEXT_PUBLIC_SUPABASE_ANON_KEY=your-public-api-key`